### PR TITLE
Add multiple shooting sounds for Enemigo_1

### DIFF
--- a/Assets/Prefabs/Enemigo_1 Variant.prefab
+++ b/Assets/Prefabs/Enemigo_1 Variant.prefab
@@ -22,11 +22,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5348906138169740389, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
       propertyPath: Priority
-      value: 50
+      value: 55
       objectReference: {fileID: 0}
     - target: {fileID: 5348906138169740389, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
       propertyPath: m_Volume
-      value: 0.6
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 5348906138169740389, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
       propertyPath: m_PlayOnAwake
@@ -40,6 +40,18 @@ PrefabInstance:
       propertyPath: sonidoDisparo
       value: 
       objectReference: {fileID: 8300000, guid: 08dd799f6a69ec4428763f7844b432fa, type: 3}
+    - target: {fileID: 6849640942425211490, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
+      propertyPath: sonidoDisparos.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6849640942425211490, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
+      propertyPath: 'sonidoDisparos.Array.data[0]'
+      value: 
+      objectReference: {fileID: 8300000, guid: 08dd799f6a69ec4428763f7844b432fa, type: 3}
+    - target: {fileID: 6849640942425211490, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
+      propertyPath: 'sonidoDisparos.Array.data[1]'
+      value: 
+      objectReference: {fileID: 8300000, guid: 7680838d27912e04bb6d1ca0c3ba1c44, type: 3}
     - target: {fileID: 8350743212542161572, guid: 5b6614aac2eada445bb77d4eab7b06c4, type: 3}
       propertyPath: m_Controller
       value: 

--- a/Assets/Scripts/Enemy_Type2/Enemigo_1/Enemigo_Disparo.cs
+++ b/Assets/Scripts/Enemy_Type2/Enemigo_1/Enemigo_Disparo.cs
@@ -11,7 +11,7 @@ public class EnemigoDisparador : MonoBehaviour
     private EnemigoMovimientoPeriodico2D movimientoEnemigo; // Referencia al script de movimiento
 
     [Header("SFX")]
-    [SerializeField] private AudioClip sonidoDisparo;
+    [SerializeField] private AudioClip[] sonidoDisparos;
     [SerializeField] private AudioSource audioSource;
 
     private Camera mainCamera;
@@ -75,8 +75,9 @@ public class EnemigoDisparador : MonoBehaviour
             float angulo = Mathf.Atan2(direccionDisparo.y, direccionDisparo.x) * Mathf.Rad2Deg;
             proyectil.transform.rotation = Quaternion.AngleAxis(angulo, Vector3.forward);
             // Reproducir sonido de disparo
-            if (audioSource != null && sonidoDisparo != null)
+            if (audioSource != null && sonidoDisparos != null)
             {
+                AudioClip sonidoDisparo = sonidoDisparos[Random.Range(0, sonidoDisparos.Length)];
                 audioSource.PlayOneShot(sonidoDisparo);
             }
         }


### PR DESCRIPTION
Updated Enemigo_Disparo.cs to support an array of shooting sounds and play a random one on each shot. Modified the Enemigo_1 Variant prefab to assign two different shooting audio clips and adjusted audio priority and volume settings.